### PR TITLE
Fix incorrectly node engine capability setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "./lib/index.js": "./lib/browser.js"
   },
   "engines": {
-    "node": "^8.3.0"
+    "node": ">=8"
   },
   "scripts": {
     "test": "npm run test-node",


### PR DESCRIPTION
Specifying the node engine capability to "^8.3.0" will cause the
the package can only be installed with the Node.js "v8.3.0".

To fix this problem, modify the node engine capability to
">=8".

See also: https://github.com/digitalbazaar/crypto-ld/issues/32